### PR TITLE
Introduced DequeWalker class to prevent excessive memory use

### DIFF
--- a/client/lib/ui/custom_widgets/__init__.py
+++ b/client/lib/ui/custom_widgets/__init__.py
@@ -1,3 +1,4 @@
 from .chatlog import Chatlog
 from .inputbox import InputBox
 from .infopanel import InfoPanel
+from .deque_walker import DequeWalker

--- a/client/lib/ui/custom_widgets/chatlog.py
+++ b/client/lib/ui/custom_widgets/chatlog.py
@@ -1,30 +1,21 @@
 import urwid as u
+from .deque_walker import DequeWalker
 
 
 class Chatlog(u.ListBox):
-
-    # TODO
-    # Nested class that handles the creation and destruction of individual message text widgets
-    # https://urwid.org/manual/widgets.html#list-walkers
-    # If you need to display a large number of widgets you should implement your own list
-    # walker that manages creating widgets as they are requested and destroying them later to
-    # avoid excessive memory use.
-    class ChatlogWalker(u.SimpleListWalker):
-        def __init__(self) -> None:
-            # Always start with no chat history (empty contents), and wrap_around set to False.
-            super().__init__(contents=[], wrap_around=False)
-
     def __init__(self) -> None:
         self.exit_focus = None
-        self.walker = self.ChatlogWalker()
-        self.size = 0
+        self.walker = DequeWalker(wrap_around=False)
 
         super().__init__(body=self.walker)
+
+    @property
+    def size(self) -> int:
+        return len(self.walker.contents)
 
     def append(self, user: str, message: str, attr: str) -> None:
         text_content = [(attr, user), f": {message}"]
         self.walker.append(u.Text(text_content))
-        self.size += 1
 
     def append_and_set_focus(self, user: str, message: str, attr: str) -> None:
         self.append(user, message, attr)

--- a/client/lib/ui/custom_widgets/deque_walker.py
+++ b/client/lib/ui/custom_widgets/deque_walker.py
@@ -1,0 +1,82 @@
+import urwid as u
+from collections import deque
+from typing import Self
+
+
+class DequeWalker(deque, u.ListWalker):
+    """This custom list walker class inherits from the :class:`deque` and :class:`ListWalker`
+    classes. This means that widgets appended to a :class:`DequeWalker` class, beyond its
+    maxlen (default 10,000 elements), results in then element at the start of the deque being
+    destroyed to prevent excessive memory use.
+
+    Raises:
+        IndexError: If attempting to access an element outside of the length or capacity of the
+        underlying deque. Additionally, attempting to retrieve a position using `next_position` or
+        `prev_position` that exceeds the deque's range with `wrap_around` set to false will raise
+        an `IndexError`.
+    """
+
+    DEFAULT_MAXLEN = 10_000
+
+    def __init__(self, wrap_around: bool = False, maxlen: int = DEFAULT_MAXLEN) -> None:
+        """
+        contents -- list to copy into this object
+
+        wrap_around -- if true, jumps to beginning/end of list on move
+
+        This class inherits :class:`deque` which means
+        it can be treated as a deque would.
+
+        Changes made to this object (when it is treated as a deque) are
+        detected automatically and will cause ListBox objects using
+        this list walker to be updated.
+        """
+        super().__init__([], maxlen=maxlen)
+        self.focus = 0
+        self.wrap_around = wrap_around
+
+    @property
+    def contents(self) -> Self:
+        return self
+
+    # def _modified(self) -> None:
+    #     if self.focus >= len(self):
+    #         self.focus = max(0, len(self) - 1)
+    #     super()._modified(self)
+
+    def set_focus(self, position: int) -> None:
+        """Set focus position."""
+
+        if not 0 <= position < len(self):
+            raise IndexError(f"No widget at position {position}")
+
+        self.focus = position
+        super()._modified()
+
+    def next_position(self, position: int) -> int:
+        """
+        Return position after start_from.
+        """
+        if len(self) - 1 <= position:
+            if self.wrap_around:
+                return 0
+            raise IndexError
+        return position + 1
+
+    def prev_position(self, position: int) -> int:
+        """
+        Return position before start_from.
+        """
+        if position <= 0:
+            if self.wrap_around:
+                return len(self) - 1
+            raise IndexError
+        return position - 1
+
+    # def positions(self, reverse: bool = False) -> Iterable[int]:
+    #     """
+    #     Optional method for returning an iterable of positions.
+    #     """
+    #     if reverse:
+    #         return range(len(self) - 1, -1, -1)
+    #     return range(len(self))

--- a/client/lib/ui/custom_widgets/deque_walker.py
+++ b/client/lib/ui/custom_widgets/deque_walker.py
@@ -39,11 +39,6 @@ class DequeWalker(deque, u.ListWalker):
     def contents(self) -> Self:
         return self
 
-    # def _modified(self) -> None:
-    #     if self.focus >= len(self):
-    #         self.focus = max(0, len(self) - 1)
-    #     super()._modified(self)
-
     def set_focus(self, position: int) -> None:
         """Set focus position."""
 
@@ -72,11 +67,3 @@ class DequeWalker(deque, u.ListWalker):
                 return len(self) - 1
             raise IndexError
         return position - 1
-
-    # def positions(self, reverse: bool = False) -> Iterable[int]:
-    #     """
-    #     Optional method for returning an iterable of positions.
-    #     """
-    #     if reverse:
-    #         return range(len(self) - 1, -1, -1)
-    #     return range(len(self))

--- a/tests/client/test_custom_widgets.py
+++ b/tests/client/test_custom_widgets.py
@@ -1,7 +1,7 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import pytest
 import urwid
-from client.lib.ui.custom_widgets import Chatlog, InputBox, InfoPanel
+from client.lib.ui.custom_widgets import Chatlog, InputBox, InfoPanel, DequeWalker
 
 
 class TestChatlog:
@@ -135,3 +135,132 @@ class TestInfoPanel:
         # When & Then
         with pytest.raises(urwid.ExitMainLoop):
             infopanel.disconnect.keypress((5, 5), "enter")
+
+
+class TestDequeWalker:
+    @pytest.fixture
+    def walker_with_wrap(self) -> DequeWalker:
+        return DequeWalker(wrap_around=True, maxlen=3)
+
+    @pytest.fixture
+    def walker_no_wrap(self) -> DequeWalker:
+        return DequeWalker(wrap_around=False, maxlen=3)
+
+    def test_append_beyond_maxlen_pops_from_left(self, walker_no_wrap):
+        # Given
+        testdata = ["1", "2", "3", "4"]
+
+        # When
+        for message in testdata:
+            t = urwid.Text(message)
+            walker_no_wrap.append(t)
+
+        # Then
+        assert len(walker_no_wrap.contents) == 3
+
+        for text_widget in walker_no_wrap.contents:
+            assert text_widget.text != testdata[0]
+
+    @patch("client.lib.ui.custom_widgets.deque_walker.u.ListWalker._modified")
+    def test_set_focus_updates_focus_and_calls_modified(
+        self, mock_modified_func, walker_no_wrap
+    ):
+        # Given
+        walker_no_wrap.append("widget0")
+        walker_no_wrap.append("widget1")
+        assert mock_modified_func.call_count == 0
+
+        # When
+        walker_no_wrap.set_focus(1)
+
+        # Then
+        assert walker_no_wrap.focus == 1
+        assert mock_modified_func.call_count == 1
+
+    def test_set_focus_updates_focus_throws_for_invalid_position(self, walker_no_wrap):
+        # Given
+        walker_no_wrap.append("widget0")
+
+        # When & Then
+        with pytest.raises(IndexError):
+            walker_no_wrap.set_focus(1)
+
+    def test_next_position_returns_expected_position(
+        self, walker_no_wrap, walker_with_wrap
+    ):
+        # Happy path, no wrap
+        # Given
+        walker_no_wrap.append("widget0")
+        walker_no_wrap.append("widget1")
+        walker_no_wrap.append("widget2")
+
+        # When
+        pos = walker_no_wrap.next_position(1)
+
+        # Then
+        assert pos == 2
+
+        # Happy path, with wrap
+        # Given
+        walker_with_wrap.append("widget0")
+        walker_with_wrap.append("widget1")
+        walker_with_wrap.append("widget2")
+
+        # When
+        pos = walker_with_wrap.next_position(1)
+        wrapped_pos_edge = walker_with_wrap.next_position(3)
+        wrapped_pos_extraneous = walker_with_wrap.next_position(30)
+
+        # Then
+        assert pos == 2
+        assert wrapped_pos_edge == 0
+        assert wrapped_pos_extraneous == 0
+
+    def test_next_position_throws_for_invalid_position(self, walker_no_wrap):
+        # Given
+        walker_no_wrap.append("widget1")
+
+        # When & Then
+        with pytest.raises(IndexError):
+            walker_no_wrap.next_position(40)
+
+    def test_prev_position_returns_expected_position(
+        self, walker_no_wrap, walker_with_wrap
+    ):
+        # Happy path, no wrap
+        # Given
+        walker_no_wrap.append("widget0")
+        walker_no_wrap.append("widget1")
+        walker_no_wrap.append("widget2")
+
+        # When
+        pos = walker_no_wrap.prev_position(1)
+
+        # Then
+        assert pos == 0
+
+        # Happy path, with wrap
+        # Given
+        walker_with_wrap.append("widget0")
+        walker_with_wrap.append("widget1")
+        walker_with_wrap.append("widget2")
+
+        # When
+        pos = walker_with_wrap.prev_position(1)
+        wrapped_pos_left_edge = walker_with_wrap.prev_position(0)
+        wrapped_pos_right_edge = walker_with_wrap.prev_position(3)
+        wrapped_pos_extraneous = walker_with_wrap.prev_position(30)
+
+        # Then
+        assert pos == 0
+        assert wrapped_pos_left_edge == 2
+        assert wrapped_pos_right_edge == 2
+        assert wrapped_pos_extraneous == 29
+
+    def test_prev_position_throws_for_invalid_position(self, walker_no_wrap):
+        # Given
+        walker_no_wrap.append("widget1")
+
+        # When & Then
+        with pytest.raises(IndexError):
+            walker_no_wrap.prev_position(-40)


### PR DESCRIPTION
Introduced a custom `ListWalker`, _`DequeWalker`_ that uses a double ended queue to prevent excessive memory use when appending messages to the chatlog.
- The implementation is inspired off of urwid's built-in [`SimpleListWalker`](https://github.com/urwid/urwid/blob/87d7327a73894ca4222876752006f9f958a4e603/urwid/widget/listbox.py#L140) class, the difference being the use of a `deque` (double ended queue) as the underlying data structure, as opposed to the `MonitoredList`.